### PR TITLE
Configure nginx reverse proxy for app stack

### DIFF
--- a/apps/web/.env.local
+++ b/apps/web/.env.local
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_API_BASE_URL=https://vpsmarcus.itts.su/api
+NEXT_PUBLIC_CMS_URL=https://cms.vpsmarcus.itts.su
+NEXT_PUBLIC_MEILI_URL=https://maili.vpsmarcus.itts.su
+NEXT_PUBLIC_MEILISEARCH_HOST=https://maili.vpsmarcus.itts.su
+NEXT_PUBLIC_MEILISEARCH_API_KEY=dev_meili_key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,40 @@
 services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:alpine
+    ports: ["80:80", "443:443"]
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - certs:/etc/nginx/certs:rw
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+    restart: unless-stopped
+    networks: [proxy]
+
+  acme-companion:
+    image: nginxproxy/acme-companion
+    environment:
+      DEFAULT_EMAIL: "admin@itts.su"
+    volumes:
+      - certs:/etc/nginx/certs
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - nginx-proxy
+    restart: unless-stopped
+    networks: [proxy]
+
   meili:
     image: getmeili/meilisearch:v1.10
     environment:
       MEILI_NO_ANALYTICS: "true"
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY:-dev_meili_key}
-    ports: ["7700:7700"]
-    volumes: [ "meili_data:/meili_data" ]
+      VIRTUAL_HOST: maili.vpsmarcus.itts.su
+      LETSENCRYPT_HOST: maili.vpsmarcus.itts.su
+      VIRTUAL_PORT: 7700
+    volumes: ["meili_data:/meili_data"]
     restart: unless-stopped
+    networks: [proxy, default]
 
   db:
     image: postgres:16-alpine
@@ -14,8 +42,7 @@ services:
       POSTGRES_DB: marcus
       POSTGRES_USER: marcus
       POSTGRES_PASSWORD: marcus
-    volumes: [ "pg_data:/var/lib/postgresql/data" ]
-    ports: ["5432:5432"]
+    volumes: ["pg_data:/var/lib/postgresql/data"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U marcus -d marcus"]
@@ -40,17 +67,22 @@ services:
       PORT: 1337
       DATABASE_CLIENT: postgres
       DATABASE_URL: postgres://marcus:marcus@db:5432/marcus
-    ports: ["1337:1337"]
+      VIRTUAL_HOST: cms.vpsmarcus.itts.su
+      LETSENCRYPT_HOST: cms.vpsmarcus.itts.su
+      VIRTUAL_PORT: 1337
     depends_on:
       db:
         condition: service_healthy
+    networks: [proxy, default]
 
   web:
     build:
       context: ./apps/web
     environment:
       NODE_ENV: development
-    ports: ["3000:3000"]
+      VIRTUAL_HOST: vpsmarcus.itts.su
+      LETSENCRYPT_HOST: vpsmarcus.itts.su
+      VIRTUAL_PORT: 3000
     depends_on:
       cms:
         condition: service_started
@@ -61,7 +93,16 @@ services:
         - action: sync
           path: ./apps/web
           target: /app
-          ignore: [ "node_modules/", ".next/" ]
+          ignore: ["node_modules/", ".next/"]
+    networks: [proxy, default]
+
+networks:
+  proxy:
+    driver: bridge
+
 volumes:
+  certs:
+  vhost:
+  html:
   meili_data:
   pg_data:


### PR DESCRIPTION
## Summary
- configure nginx-proxy and acme-companion to front the stack with automated TLS and hostname-based routing
- move application containers behind the proxy network and annotate them with virtual host metadata for certificate issuance
- update the web environment defaults to point to the HTTPS CMS and Meilisearch endpoints

## Testing
- not run (not requested)

## References
- Internal: docs/Утверждённое с заказчиком ТЗ.md → Архитектура и стек
- Internal: docs/Результаты и демонстрация по этапам.md → Этап 1 — Архитектура и DevOps (VDS)


------
https://chatgpt.com/codex/tasks/task_b_68dc168d9d288329902ca7519db4c42e