### PR TITLE
Configure certbot SAN issuance for vpsmarcus.itts.su

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,12 @@ pnpm run strapi import -f export-data.tar
 ## Certbot 🤖
 #### Obtaining ssl certificate:
 ```
-docker compose -f production.compose.yml run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d [domain-name]
+docker compose -f production.compose.yml run --rm certbot certonly \
+  --webroot --webroot-path /var/www/certbot/ \
+  -d vpsmarcus.itts.su \
+  -d www.vpsmarcus.itts.su \
+  -d api.vpsmarcus.itts.su \
+  -d cms.vpsmarcus.itts.su
 ```
+
+Сертификат для всех SAN-доменов появится в `certbot/conf/live/vpsmarcus.itts.su/`. После получения сертификата перезапусти `nginx`, чтобы он подхватил новые файлы.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -10,14 +10,18 @@ server {
   listen 80;
   listen [::]:80;
 
-  server_name [domain-name] www.[domain-name];
+  server_name vpsmarcus.itts.su www.vpsmarcus.itts.su;
 
   location /.well-known/acme-challenge/ {
     root /var/www/certbot;
   }
 
   location / {
-    return 301 https://[domain-name]$request_uri;
+    return 301 https://vpsmarcus.itts.su$request_uri;
+  }
+
+  location /strapi {
+    return 308 https://api.vpsmarcus.itts.su$request_uri;
   }
 }
 
@@ -26,10 +30,10 @@ server {
   listen [::]:443 ssl;
   http2 on;
 
-  server_name [domain-name] www.[domain-name];
+  server_name vpsmarcus.itts.su www.vpsmarcus.itts.su;
 
-  ssl_certificate /etc/nginx/ssl/live/[domain-name]/fullchain.pem;
-  ssl_certificate_key /etc/nginx/ssl/live/[domain-name]/privkey.pem;
+  ssl_certificate /etc/nginx/ssl/live/vpsmarcus.itts.su/fullchain.pem;
+  ssl_certificate_key /etc/nginx/ssl/live/vpsmarcus.itts.su/privkey.pem;
 
   location / {
     proxy_pass http://frontend_upstream;
@@ -51,9 +55,34 @@ server {
     proxy_cache_valid 60m;
     proxy_pass http://frontend_upstream;
   }
+}
 
-  location /strapi/ {
-    rewrite ^/strapi/?(.*)$ /$1 break;
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name api.vpsmarcus.itts.su cms.vpsmarcus.itts.su;
+
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
+  location / {
+    return 301 https://api.vpsmarcus.itts.su$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
+
+  server_name api.vpsmarcus.itts.su cms.vpsmarcus.itts.su;
+
+  ssl_certificate /etc/nginx/ssl/live/vpsmarcus.itts.su/fullchain.pem;
+  ssl_certificate_key /etc/nginx/ssl/live/vpsmarcus.itts.su/privkey.pem;
+
+  location / {
     proxy_pass http://strapi_upstream;
     proxy_http_version 1.1;
     proxy_set_header X-Forwarded-Host $host;
@@ -67,8 +96,7 @@ server {
     proxy_pass_request_headers on;
   }
 
-  location /strapi/_health {
-    rewrite ^/strapi/_health/?(.*)$ /$1 break;
+  location /_health {
     proxy_pass http://strapi_upstream;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
## Summary
- configure nginx virtual hosts for vpsmarcus.itts.su frontend and api/cms subdomains with the shared certificate path
- document the certbot SAN issuance command covering vpsmarcus.itts.su and service subdomains

## Testing
- Not run (not requested)

## References
- Internal: README.md → Certbot 🤖

------
https://chatgpt.com/codex/tasks/task_b_68dc5d2be6308329abe53557716aa6bb