### PR TITLE
docs: актуализировать отчёт по архитектуре

### DIFF
--- a/docs/Отчёт по работам за 30.09.2025.md
+++ b/docs/Отчёт по работам за 30.09.2025.md
@@ -1,92 +1,72 @@
-Отчёт по работам за сегодня --- 30 сентября 2025
+Отчёт по актуальному состоянию инфраструктуры и архитектуры — 30 сентября 2025
 
-**Резюме**
+## Резюме
 
-Стек в Docker поднят и стабилизирован. Strapi успешно стартует,
-Meilisearch доступен и требует авторизацию по ключу, веб-приложение
-Next.js отвечает и обновления контента применяются после перезапуска
-контейнера web. Критичные ошибки (ENOSPC, отсутствие каталога загрузок)
-устранены.
+- Базовый стек подтверждён: **Next.js 15.5.3 (App Router, React 19)**, **Strapi v5.23.6**, **PostgreSQL 14-alpine**, **Meilisearch v1.7**, **Nginx + Certbot**.
+- Все сервисы упакованы в Docker и управляются двумя compose-файлами (`development.compose.yml` и `production.compose.yml`). В качестве базового образа в Node-сервисах используется **node:22-alpine** с глобально установленным `pnpm`.
+- Дев-сборка фронтенда и Strapi работает в режиме `pnpm dev`/`pnpm develop` с подключенными volume для `src` и `public`, что даёт горячую перезагрузку без пересборки контейнеров.
+- Продовая цепочка фронтенда включает healthcheck-скрипт ожидания `/_health` Strapi и выполняет `pnpm build` перед запуском `pnpm start`, обеспечивая консистентность схемы данных и контента.
 
-**Что сделано**
+## Компоненты
 
-**Инфраструктура / контейнеры**
+### Frontend (Next.js)
+- Next.js 15.5.3 с App Router (`src/app`) и стандартным layout. Пока используется шаблонная страница `page.tsx`.
+- Зависимости: React/React DOM 19.1.0, TypeScript 5, ESLint 9, `eslint-config-next`.
+- `next.config.ts` прокидывает окружение (`API_CONTAINER_URL`, `API_CLIENT_URL`, `API_TOKEN`, `NEXT_PUBLIC_MEILISEARCH_HOST`, `NEXT_PUBLIC_MEILISEARCH_API_KEY`) в рантайм.
+- Дев Dockerfile (`docker/development/Dockerfile.frontend`): `pnpm install`, команду `pnpm run dev`, проброс портов `3000`, volumes для `public` и `src` → HMR без rebuild.
+- Прод Dockerfile (`docker/production/Dockerfile.frontend`): устанавливает `curl`, глобально `pnpm`, копирует исходники, прописывает ENV из build-аргументов. Точка входа — `healthcheck.strapi.sh`, который ждёт доступности `http://strapi:1337/_health`, выполняет `pnpm build`, затем `pnpm start` (порт 3000).
 
--   Собран и запущен базовый стек docker compose с сервисами **db
-    (Postgres 16)**, **cms (Strapi v5)**, **web (Next.js)**, **meili
-    (Meilisearch 1.10)**.
+### CMS (Strapi)
+- Strapi 5.23.6 с базовыми плагинами (`@strapi/plugin-users-permissions`, `@strapi/plugin-cloud`) и интеграцией `strapi-plugin-meilisearch`.
+- Конфигурация БД (`config/database.ts`): поддержка postgres/mysql/sqlite, дефолт — postgres с параметрами из ENV (`DATABASE_*`, `DATABASE_URL`).
+- Конфигурация сервера (`config/server.ts`): прокидывает `API_CLIENT_URL` в `url`, ключи приложения читаются из `APP_KEYS`.
+- Плагины (`config/plugins.ts`): Meilisearch активируется при наличии `MEILISEARCH_HOST` и `MEILISEARCH_MASTER_KEY`.
+- Дев Dockerfile (`docker/development/Dockerfile.strapi`): `pnpm run develop`, volumes на `config`, `database`, `public`, `src`.
+- Прод Dockerfile (`docker/production/Dockerfile.strapi`): билд `pnpm run build`, запуск `pnpm run start`. В рантайме ожидает postgres и meilisearch (через `depends_on`).
+- Контентные типы пока не заведены (`src/api` пустой), админка — дефолтная (примерный `app.example.tsx`).
 
--   Для Strapi создан каталог загрузок и смонтирован в контейнер:
+### База данных
+- Postgres 14-alpine, volume `postgresql_database` (dev) / `postgres-data` (prod). Авторизация через `DATABASE_USERNAME`/`DATABASE_PASSWORD`.
+- Для Strapi схема по умолчанию `public`, в env доступна опциональная `DATABASE_SCHEMA`.
 
-    -   mkdir -p apps/cms/public/uploads → устранило падение провайдера
-        загрузок (local) на старте. В Strapi локальный провайдер
-        сохраняет файлы на диск в ./public/uploads.
+### Поиск
+- Meilisearch `getmeili/meilisearch:v1.7`, volume `meilisearch_data`/`meilisearch-data`.
+- Ключи: `MEILISEARCH_MASTER_KEY` используется и Strapi, и фронтендом (`NEXT_PUBLIC_MEILISEARCH_API_KEY` на данный момент совпадает и требует ограничений на проде).
 
--   Увеличены лимиты inotify, чтобы убрать ошибку ENOSPC: System limit
-    for number of file watchers reached при дев-сборке админки Strapi:
+### Веб-сервер и SSL
+- Production compose добавляет `nginx` и `certbot`.
+- `nginx/default.conf`:
+  - Отдельные upstream для `frontend:3000` и `strapi:1337`.
+  - HTTP-запросы на основной домен перенаправляются на HTTPS, `/strapi` → `api`-поддомен.
+  - HTTPS-конфиг проксирует Next.js и Strapi, включает кеширование `/static` и `/_next/static`.
+  - Для Strapi проброшен `_health` для внешних проверок.
+- `nginx/healthcheck.frontend.sh` ждёт отклика Next.js перед стартом nginx (использовать как entrypoint при необходимости).
+- `certbot` обслуживает HTTP-01 challenge через `/var/www/certbot`, сертификаты ожидаются в `certbot/conf/live/vpsmarcus.itts.su/`.
 
-    -   применено fs.inotify.max_user_watches=524288 и
-        fs.inotify.max_user_instances=1024 через
-        /etc/sysctl.d/99-inotify.conf и sysctl \--system.
+## Compose-профили
 
-**Диагностика и проверки доступности**
+### Development (`docker/development.compose.yml`)
+- Сервисы: `frontend`, `strapi`, `database`, `meilisearch` в сети `internal`.
+- `frontend` зависит от `strapi`, подключается к API через `API_CONTAINER_URL` (обычно `http://strapi:1337`).
+- Обновление кода происходит через смонтированные каталоги, hot reload доступен без пересоздания образа.
 
--   **Meilisearch**
+### Production (`docker/production.compose.yml`)
+- Сервисы: `nginx`, `certbot`, `frontend`, `strapi`, `database`, `meilisearch`.
+- `frontend` и `strapi` подтягивают ENV через build args; для frontend дополнительно пробрасываются директории `public/src` (упростит замену статики без rebuild).
+- `strapi` ожидает `database` и `meilisearch`; `frontend` запускается после успешного healthcheck Strapi.
+- Рестарт-политика `unless-stopped` на всех сервисах, кроме `certbot`.
 
-    -   /health → **200 OK**.
+## Операционные наблюдения
 
-    -   /indexes без заголовка авторизации → **401 Unauthorized**; с
-        Authorization: Bearer dev_meili_key → **200 OK**. В актуальных
-        версиях Meilisearch доступ к API защищён заголовком
-        Authorization: Bearer \<API_KEY\>.
-        ([meilisearch.com](https://www.meilisearch.com/docs/reference/api/similar?utm_source=chatgpt.com))
+- Стартовый `_health` Strapi (встроенный в v5) обеспечивает корректную последовательность запуска фронтенда в проде.
+- Дев-режим Next.js не требует увеличения лимитов inotify: HMR работает штатно благодаря volume и `WATCHPACK_POLLING=true`.
+- Для prod следует сгенерировать отдельный search-only ключ Meilisearch и отдать его фронтенду вместо master key.
+- Добавление favicon и базовых страниц снизит шум 404 в логах nginx и Strapi.
+- Из компонентов, обозначенных в «Проектирование интернет-магазина Marcus (Next.js + Strapi).md», пока не внедрены Redis, S3/CDN и автоматизация CI/CD — требуется учесть их в дорожной карте.
 
--   **Strapi**
+## Следующие шаги
 
-    -   Панель админки GET /admin → **200 OK**, сервис стартует: "Strapi
-        started successfully".
-
-    -   В логах фиксировались 500 на GET /favicon.ico --- это ожидаемо
-        при отсутствии файла и использовании middleware koa-favicon.
-        Добавление favicon.ico устранит шум в логах. (GitHub)
-
--   **Next.js (web)**
-
-    -   Корень сайта GET / → **200 OK**.
-
-    -   Обновление контента подтвердилось после **перезапуска контейнера
-        web**. Внутри контейнера видна продакшн-сборка Next.js в режиме
-        *standalone* (.next/standalone, server.js), что объясняет
-        отсутствие исходников в контейнере и необходимость пересборки
-        образа/перезапуска для применения изменений. Режим *Standalone
-        Output* формирует минимальный сервер и выкладку, отделяя
-        зависимости от исходников.
-
-**Улучшения DX**
-
--   Воспользовались механизмом **docker compose watch** (секция
-    develop.watch) для автоматической синхронизации/пересборки
-    web-сервиса во время разработки. Это штатная функция Compose для
-    дев-циклов.
-
-**Логи/артефакты (ключевые)**
-
--   Strapi:
-
-    -   Strapi started successfully; GET /admin → 200.
-
-    -   Ошибка до фикса: The upload folder (/app/public/uploads)
-        doesn\'t exist... --- устранена созданием каталога.
-
--   Meilisearch:
-
-    -   GET /health → 200.
-
-    -   GET /indexes → 401 без заголовка; 200 с Authorization: Bearer
-        dev_meili_key.
-
--   Next.js:
-
-    -   После правок в page.tsx контент обновился **после перезапуска
-        web** (с учётом того, что контейнер собирает образ с
-        продакшн-сборкой в режиме standalone).
+1. Завести базовые коллекции в Strapi согласно ТЗ и обновить meilisearch-индексацию.
+2. Вынести search-only ключ в переменные окружения фронтенда.
+3. Настроить CI на запуск `pnpm -w lint` / `pnpm -w typecheck` по инструкциям из корневого `AGENTS.md`.
+4. Подготовить `docs/DECISIONS.md` при первом отступлении от ТЗ.


### PR DESCRIPTION
## Summary
- обновил документ "Отчёт по работам за 30.09.2025" согласно фактической инфраструктуре и конфигурации репозитория
- зафиксировал расхождения с проектной документацией (отсутствие Redis, S3/CDN, CI/CD) и вынес их в план работ

## Testing
- not run (documentation only)

## References
- Internal: docs/Проектирование интернет-магазина Marcus (Next.js + Strapi).md → § Архитектура приложения

------
https://chatgpt.com/codex/tasks/task_b_68dcced4eaa88329a0cd66e23ea3b5e0