### PR TITLE
Add 03.10.2025 infrastructure status report

### DIFF
--- a/docs/Отчёт по работам за 03.10.2025.md
+++ b/docs/Отчёт по работам за 03.10.2025.md
@@ -1,0 +1,60 @@
+Отчёт по актуальному состоянию инфраструктуры и архитектуры — 03 октября 2025
+
+## Summary
+
+- Архитектурные допущения и стек по-прежнему совпадают с ТЗ: Next.js 15.5.3 (App Router, React 19), Strapi v5.23.6, PostgreSQL 14-alpine, Meilisearch v1.7, Nginx + Certbot.
+- Репозиторий содержит только инфраструктурный каркас: docker-compose (dev/prod), Dockerfile для фронтенда и CMS, healthcheck-скрипты. Функциональные сервисы не реализованы (Strapi без контент-типов, Next.js в состоянии шаблона).
+- Набор переменных окружения и последовательность запуска сервисов проверены: healthcheck Strapi перед стартом фронтенда, volumes для dev-режима дают HMR без пересборки.
+- Запланированные шаги остаются прежними: завести схемы в Strapi, вынести search-only ключ Meilisearch, поднять CI под pnpm lint/typecheck.
+
+## Diff относительно отчёта за 30.09.2025
+
+- Состояние кода и инфраструктуры не изменилось: активных коммитов после 30.09.2025 нет, структура docker-compose и конфигов идентична.
+- Новых компонент или интеграций не появилось: Strapi по-прежнему без API (`src/api` пустой), Next.js — стартовый шаблон.
+- Запланированные следующие шаги совпадают с предыдущими: фокус на моделировании данных, поиске и CI.
+
+## Детализация по компонентам (без изменений)
+
+### Frontend (Next.js)
+- Версия и конфиг: Next.js 15.5.3, App Router (`src/app`), стандартный layout, единственная страница `page.tsx`.
+- Зависимости: React/React DOM 19.1.0, TypeScript 5, ESLint 9, `eslint-config-next`.
+- Конфиг окружения (`next.config.ts`): проброс `API_CONTAINER_URL`, `API_CLIENT_URL`, `API_TOKEN`, `NEXT_PUBLIC_MEILISEARCH_HOST`, `NEXT_PUBLIC_MEILISEARCH_API_KEY`.
+- Docker (dev): `docker/development/Dockerfile.frontend` — `pnpm install`, `pnpm run dev`, volumes на `public` и `src` → горячая перезагрузка.
+- Docker (prod): `docker/production/Dockerfile.frontend` — установка `pnpm`, копирование исходников, запуск `healthcheck.strapi.sh` → `pnpm build` → `pnpm start` (порт 3000).
+
+### CMS (Strapi)
+- Версия 5.23.6 с базовыми плагинами (`@strapi/plugin-users-permissions`, `@strapi/plugin-cloud`, `strapi-plugin-meilisearch`).
+- Конфиги: `config/database.ts` (PostgreSQL по умолчанию, env-переменные), `config/server.ts` (URL + `APP_KEYS`), `config/plugins.ts` (условное включение Meilisearch).
+- Docker (dev): `docker/development/Dockerfile.strapi` — `pnpm run develop`, volumes на `config`, `database`, `public`, `src`.
+- Docker (prod): `docker/production/Dockerfile.strapi` — `pnpm run build`, `pnpm run start`, ожидание postgres и meilisearch.
+- Контент-типов и кастомной админки нет, `src/api` пуст.
+
+### База данных
+- PostgreSQL 14-alpine, volume `postgresql_database` (dev) / `postgres-data` (prod), авторизация через `DATABASE_USERNAME`/`DATABASE_PASSWORD`.
+- Возможность задать `DATABASE_SCHEMA` через env.
+
+### Поиск
+- Meilisearch `getmeili/meilisearch:v1.7`, volume `meilisearch_data` (dev) / `meilisearch-data` (prod).
+- Используется master key: `MEILISEARCH_MASTER_KEY` одновременно для Strapi и фронтенда (требуется выделить search-only ключ).
+
+### Веб-сервер и SSL
+- Production compose включает `nginx` и `certbot`.
+- `nginx/default.conf`: upstream `frontend:3000` / `strapi:1337`, редирект HTTP→HTTPS, прокси `/strapi` на API, кеш `/static` и `/_next/static`, проброс `/_health` Strapi.
+- `nginx/healthcheck.frontend.sh` ждёт отклика Next.js перед стартом nginx.
+- `certbot` обслуживает HTTP-01 challenge в `/var/www/certbot`, ожидаемые сертификаты — `certbot/conf/live/vpsmarcus.itts.su/`.
+
+### Compose-профили
+- Development (`docker/development.compose.yml`): `frontend`, `strapi`, `database`, `meilisearch` в сети `internal`, зависимости `frontend` от `strapi`.
+- Production (`docker/production.compose.yml`): `nginx`, `certbot`, `frontend`, `strapi`, `database`, `meilisearch`; рестарт-политика `unless-stopped`, `frontend` запускается после healthcheck Strapi.
+
+### Операционные наблюдения
+- Healthcheck Strapi обеспечивает корректный старт фронтенда.
+- HMR Next.js стабильный благодаря volume и `WATCHPACK_POLLING=true`.
+- Для прода по-прежнему требуется выделенный search-only ключ, добавление favicon/базовых страниц и внедрение Redis/S3/CDN.
+
+## Следующие шаги (актуальны на 03.10.2025)
+
+1. Создать базовые коллекции Strapi по ТЗ и настроить синхронизацию с Meilisearch.
+2. Вынести search-only ключ Meilisearch в отдельные env переменные фронтенда.
+3. Настроить CI с запуском `pnpm -w lint` и `pnpm -w typecheck`.
+4. Завести `docs/DECISIONS.md` при первом отступлении от проектной документации.


### PR DESCRIPTION
## Summary
- Added the 03.10.2025 status report to the docs with explicit diff versus the 30.09.2025 report.

## Testing
- Not run (documentation-only change)

## References
- Internal: docs/Отчёт по работам за 30.09.2025.md
- Internal: docs/Результаты и демонстрация по этапам.md

------
https://chatgpt.com/codex/tasks/task_b_68dedaf2ab188329b3307cf12b655adb