### PR TITLE
Align S3 upload provider config with AWS example

### DIFF
--- a/strapi/config/plugins.ts
+++ b/strapi/config/plugins.ts
@@ -42,13 +42,16 @@ export default ({ env }: { env: any }) => {
       config: {
         provider: 'aws-s3',
         providerOptions: {
-          accessKeyId: env('AWS_ACCESS_KEY_ID'),
-          secretAccessKey: env('AWS_ACCESS_SECRET'),
-          region: env('AWS_REGION'),
+          accessKeyId: env('S3_ACCESS_KEY_ID'),
+          secretAccessKey: env('S3_SECRET_ACCESS_KEY'),
+          region: env('S3_REGION'),
+          ...(env('S3_ENDPOINT') ? { endpoint: env('S3_ENDPOINT') } : {}),
+          forcePathStyle: env.bool('S3_FORCE_PATH_STYLE', false),
+          baseUrl: env('S3_CDN_BASE_URL'),
           params: {
-            ACL: env('AWS_ACL', 'public-read'),
-            signedUrlExpires: env('AWS_SIGNED_URL_EXPIRES', 15 * 60),
-            Bucket: env('AWS_BUCKET'),
+            ACL: env('S3_ACL', 'public-read'),
+            signedUrlExpires: env.int('S3_SIGNED_URL_EXPIRES', 15 * 60),
+            Bucket: env('S3_BUCKET'),
           },
         },
         actionOptions: {

--- a/strapi/config/plugins.ts
+++ b/strapi/config/plugins.ts
@@ -42,18 +42,14 @@ export default ({ env }: { env: any }) => {
       config: {
         provider: 'aws-s3',
         providerOptions: {
-          s3Options: {
-            credentials: {
-              accessKeyId: env('S3_ACCESS_KEY_ID'),
-              secretAccessKey: env('S3_SECRET_ACCESS_KEY'),
-            },
-            region: env('S3_REGION'),
-            endpoint: env('S3_ENDPOINT'),
-            forcePathStyle: env.bool('S3_FORCE_PATH_STYLE', false),
+          accessKeyId: env('AWS_ACCESS_KEY_ID'),
+          secretAccessKey: env('AWS_ACCESS_SECRET'),
+          region: env('AWS_REGION'),
+          params: {
+            ACL: env('AWS_ACL', 'public-read'),
+            signedUrlExpires: env('AWS_SIGNED_URL_EXPIRES', 15 * 60),
+            Bucket: env('AWS_BUCKET'),
           },
-          bucket: env('S3_BUCKET'),
-          baseUrl: env('S3_CDN_BASE_URL'),
-          rootPath: '',
         },
         actionOptions: {
           upload: {},


### PR DESCRIPTION
## Summary
- align the Strapi AWS S3 provider options with the canonical AWS configuration
- ensure ACL, signed URL expiration, and bucket parameters are passed via provider params

## Testing
- not run (not requested)

## References
- Internal: n/a
- External: n/a

------
https://chatgpt.com/codex/tasks/task_b_68e0433f09c08329ad31d48e56ce9221