### PR TITLE
fix: align site setting content-type key

### DIFF
--- a/strapi/src/api/about-page/content-types/about-page/schema.json
+++ b/strapi/src/api/about-page/content-types/about-page/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "singleType",
+  "collectionName": "about_page",
+  "info": {
+    "singularName": "about-page",
+    "pluralName": "about-pages",
+    "displayName": "About page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "hero": {
+      "type": "component",
+      "component": "page.hero"
+    },
+    "sections": {
+      "type": "dynamiczone",
+      "components": [
+        "shared.rich-block",
+        "page.media-text",
+        "page.cards-grid",
+        "page.accordion",
+        "page.cta",
+        "page.hero",
+        "page.faq-list"
+      ]
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/strapi/src/api/about-page/controllers/about_page.ts
+++ b/strapi/src/api/about-page/controllers/about_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::about-page.about-page');

--- a/strapi/src/api/about-page/routes/about_page.ts
+++ b/strapi/src/api/about-page/routes/about_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::about-page.about-page');

--- a/strapi/src/api/about-page/services/about_page.ts
+++ b/strapi/src/api/about-page/services/about_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::about-page.about-page');

--- a/strapi/src/api/article/content-types/article/schema.json
+++ b/strapi/src/api/article/content-types/article/schema.json
@@ -1,0 +1,51 @@
+{
+  "kind": "collectionType",
+  "collectionName": "articles",
+  "info": {
+    "singularName": "article",
+    "pluralName": "articles",
+    "displayName": "Article"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "cover": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false,
+      "required": true
+    },
+    "excerpt": {
+      "type": "text"
+    },
+    "body": {
+      "type": "dynamiczone",
+      "components": [
+        "shared.rich-block",
+        "page.media-text",
+        "page.cards-grid",
+        "page.accordion",
+        "page.cta",
+        "page.hero",
+        "page.faq-list"
+      ]
+    },
+    "tags": {
+      "type": "json"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/strapi/src/api/article/controllers/article.ts
+++ b/strapi/src/api/article/controllers/article.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::article.article');

--- a/strapi/src/api/article/routes/article.ts
+++ b/strapi/src/api/article/routes/article.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::article.article');

--- a/strapi/src/api/article/services/article.ts
+++ b/strapi/src/api/article/services/article.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::article.article');

--- a/strapi/src/api/attribute-value/content-types/attribute-value/schema.json
+++ b/strapi/src/api/attribute-value/content-types/attribute-value/schema.json
@@ -1,0 +1,50 @@
+{
+  "kind": "collectionType",
+  "collectionName": "attribute_values",
+  "info": {
+    "singularName": "attribute-value",
+    "pluralName": "attribute-values",
+    "displayName": "Attribute value"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "value": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "value",
+      "required": true
+    },
+    "numericValue": {
+      "type": "decimal"
+    },
+    "hex": {
+      "type": "string"
+    },
+    "order": {
+      "type": "integer"
+    },
+    "attribute": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::attribute.attribute",
+      "inversedBy": "values"
+    },
+    "products": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product.product",
+      "mappedBy": "attributeValues"
+    },
+    "variants": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product-variant.product-variant",
+      "mappedBy": "attributeValues"
+    }
+  }
+}

--- a/strapi/src/api/attribute-value/controllers/attribute_value.ts
+++ b/strapi/src/api/attribute-value/controllers/attribute_value.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::attribute-value.attribute-value');

--- a/strapi/src/api/attribute-value/routes/attribute_value.ts
+++ b/strapi/src/api/attribute-value/routes/attribute_value.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::attribute-value.attribute-value');

--- a/strapi/src/api/attribute-value/services/attribute_value.ts
+++ b/strapi/src/api/attribute-value/services/attribute_value.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::attribute-value.attribute-value');

--- a/strapi/src/api/attribute/content-types/attribute/schema.json
+++ b/strapi/src/api/attribute/content-types/attribute/schema.json
@@ -1,0 +1,44 @@
+{
+  "kind": "collectionType",
+  "collectionName": "attributes",
+  "info": {
+    "singularName": "attribute",
+    "pluralName": "attributes",
+    "displayName": "Attribute"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "code": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "kind": {
+      "type": "enumeration",
+      "enum": ["text", "number", "color", "size", "volume"],
+      "default": "text"
+    },
+    "unit": {
+      "type": "string"
+    },
+    "isFacet": {
+      "type": "boolean",
+      "default": false
+    },
+    "order": {
+      "type": "integer"
+    },
+    "values": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::attribute-value.attribute-value",
+      "mappedBy": "attribute"
+    }
+  }
+}

--- a/strapi/src/api/attribute/controllers/attribute.ts
+++ b/strapi/src/api/attribute/controllers/attribute.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::attribute.attribute');

--- a/strapi/src/api/attribute/routes/attribute.ts
+++ b/strapi/src/api/attribute/routes/attribute.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::attribute.attribute');

--- a/strapi/src/api/attribute/services/attribute.ts
+++ b/strapi/src/api/attribute/services/attribute.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::attribute.attribute');

--- a/strapi/src/api/brand/content-types/brand/schema.json
+++ b/strapi/src/api/brand/content-types/brand/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "brands",
+  "info": {
+    "singularName": "brand",
+    "pluralName": "brands",
+    "displayName": "Brand"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "products": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::product.product",
+      "mappedBy": "brand"
+    }
+  }
+}

--- a/strapi/src/api/brand/controllers/brand.ts
+++ b/strapi/src/api/brand/controllers/brand.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::brand.brand');

--- a/strapi/src/api/brand/routes/brand.ts
+++ b/strapi/src/api/brand/routes/brand.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::brand.brand');

--- a/strapi/src/api/brand/services/brand.ts
+++ b/strapi/src/api/brand/services/brand.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::brand.brand');

--- a/strapi/src/api/case/content-types/case/schema.json
+++ b/strapi/src/api/case/content-types/case/schema.json
@@ -1,0 +1,86 @@
+{
+  "kind": "collectionType",
+  "collectionName": "cases",
+  "info": {
+    "singularName": "case",
+    "pluralName": "cases",
+    "displayName": "Case"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "client": {
+      "type": "string"
+    },
+    "eventDate": {
+      "type": "date"
+    },
+    "material": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::material.material",
+      "inversedBy": "cases"
+    },
+    "appliedMethods": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::printing-method.printing-method",
+      "inversedBy": "cases"
+    },
+    "colorsUsed": {
+      "type": "component",
+      "component": "product.attribute-badge",
+      "repeatable": true
+    },
+    "images": {
+      "type": "component",
+      "component": "shared.image",
+      "repeatable": true
+    },
+    "spec": {
+      "type": "component",
+      "component": "product.spec-item",
+      "repeatable": true
+    },
+    "content": {
+      "type": "dynamiczone",
+      "components": [
+        "shared.rich-block",
+        "page.media-text",
+        "page.cards-grid",
+        "page.accordion",
+        "page.cta",
+        "page.hero",
+        "page.faq-list"
+      ]
+    },
+    "product": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product.product",
+      "inversedBy": "cases"
+    },
+    "likes": {
+      "type": "integer",
+      "default": 0
+    },
+    "views": {
+      "type": "integer",
+      "default": 0
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/strapi/src/api/case/controllers/case.ts
+++ b/strapi/src/api/case/controllers/case.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::case.case');

--- a/strapi/src/api/case/routes/case.ts
+++ b/strapi/src/api/case/routes/case.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::case.case');

--- a/strapi/src/api/case/services/case.ts
+++ b/strapi/src/api/case/services/case.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::case.case');

--- a/strapi/src/api/category/content-types/category/schema.json
+++ b/strapi/src/api/category/content-types/category/schema.json
@@ -1,0 +1,67 @@
+{
+  "kind": "collectionType",
+  "collectionName": "categories",
+  "info": {
+    "singularName": "category",
+    "pluralName": "categories",
+    "displayName": "Category"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "icon": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    },
+    "cover": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    },
+    "summary": {
+      "type": "text"
+    },
+    "landing": {
+      "type": "dynamiczone",
+      "components": [
+        "shared.rich-block",
+        "page.media-text",
+        "page.cards-grid",
+        "page.accordion",
+        "page.cta"
+      ]
+    },
+    "sort": {
+      "type": "integer"
+    },
+    "parent": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::category.category",
+      "inversedBy": "children"
+    },
+    "children": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::category.category",
+      "mappedBy": "parent"
+    },
+    "products": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product.product",
+      "mappedBy": "subCategories"
+    }
+  }
+}

--- a/strapi/src/api/category/controllers/category.ts
+++ b/strapi/src/api/category/controllers/category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::category.category');

--- a/strapi/src/api/category/routes/category.ts
+++ b/strapi/src/api/category/routes/category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::category.category');

--- a/strapi/src/api/category/services/category.ts
+++ b/strapi/src/api/category/services/category.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::category.category');

--- a/strapi/src/api/contacts-page/content-types/contacts-page/schema.json
+++ b/strapi/src/api/contacts-page/content-types/contacts-page/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "singleType",
+  "collectionName": "contacts_page",
+  "info": {
+    "singularName": "contacts-page",
+    "pluralName": "contacts-pages",
+    "displayName": "Contacts page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "text"
+    },
+    "channels": {
+      "type": "component",
+      "component": "contact.channel",
+      "repeatable": true
+    },
+    "locations": {
+      "type": "component",
+      "component": "contact.location",
+      "repeatable": true
+    },
+    "mapEmbed": {
+      "type": "text"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/strapi/src/api/contacts-page/controllers/contacts_page.ts
+++ b/strapi/src/api/contacts-page/controllers/contacts_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::contacts-page.contacts-page');

--- a/strapi/src/api/contacts-page/routes/contacts_page.ts
+++ b/strapi/src/api/contacts-page/routes/contacts_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::contacts-page.contacts-page');

--- a/strapi/src/api/contacts-page/services/contacts_page.ts
+++ b/strapi/src/api/contacts-page/services/contacts_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::contacts-page.contacts-page');

--- a/strapi/src/api/design-template/content-types/design-template/schema.json
+++ b/strapi/src/api/design-template/content-types/design-template/schema.json
@@ -1,0 +1,38 @@
+{
+  "kind": "collectionType",
+  "collectionName": "design_templates",
+  "info": {
+    "singularName": "design-template",
+    "pluralName": "design-templates",
+    "displayName": "Design template"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "file": {
+      "type": "media",
+      "allowedTypes": ["files"],
+      "multiple": false,
+      "required": true
+    },
+    "note": {
+      "type": "text"
+    },
+    "product": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product.product",
+      "inversedBy": "designTemplates"
+    },
+    "variant": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product-variant.product-variant"
+    }
+  }
+}

--- a/strapi/src/api/design-template/controllers/design_template.ts
+++ b/strapi/src/api/design-template/controllers/design_template.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::design-template.design-template');

--- a/strapi/src/api/design-template/routes/design_template.ts
+++ b/strapi/src/api/design-template/routes/design_template.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::design-template.design-template');

--- a/strapi/src/api/design-template/services/design_template.ts
+++ b/strapi/src/api/design-template/services/design_template.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::design-template.design-template');

--- a/strapi/src/api/faq-item/content-types/faq-item/schema.json
+++ b/strapi/src/api/faq-item/content-types/faq-item/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "collectionType",
+  "collectionName": "faq_items",
+  "info": {
+    "singularName": "faq-item",
+    "pluralName": "faq-items",
+    "displayName": "FAQ item"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "question": {
+      "type": "string",
+      "required": true
+    },
+    "answer": {
+      "type": "richtext",
+      "required": true
+    },
+    "order": {
+      "type": "integer"
+    },
+    "topic": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::help-topic.help-topic",
+      "inversedBy": "faqItems"
+    }
+  }
+}

--- a/strapi/src/api/faq-item/controllers/faq_item.ts
+++ b/strapi/src/api/faq-item/controllers/faq_item.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::faq-item.faq-item');

--- a/strapi/src/api/faq-item/routes/faq_item.ts
+++ b/strapi/src/api/faq-item/routes/faq_item.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::faq-item.faq-item');

--- a/strapi/src/api/faq-item/services/faq_item.ts
+++ b/strapi/src/api/faq-item/services/faq_item.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::faq-item.faq-item');

--- a/strapi/src/api/footer/content-types/footer/schema.json
+++ b/strapi/src/api/footer/content-types/footer/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "singleType",
+  "collectionName": "footer",
+  "info": {
+    "singularName": "footer",
+    "pluralName": "footers",
+    "displayName": "Footer"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "columns": {
+      "type": "component",
+      "component": "navigation.footer-column",
+      "repeatable": true
+    },
+    "contacts": {
+      "type": "component",
+      "component": "contact.channel",
+      "repeatable": true
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    },
+    "copyright": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/api/footer/controllers/footer.ts
+++ b/strapi/src/api/footer/controllers/footer.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::footer.footer');

--- a/strapi/src/api/footer/routes/footer.ts
+++ b/strapi/src/api/footer/routes/footer.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::footer.footer');

--- a/strapi/src/api/footer/services/footer.ts
+++ b/strapi/src/api/footer/services/footer.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::footer.footer');

--- a/strapi/src/api/help-topic/content-types/help-topic/schema.json
+++ b/strapi/src/api/help-topic/content-types/help-topic/schema.json
@@ -1,0 +1,43 @@
+{
+  "kind": "collectionType",
+  "collectionName": "help_topics",
+  "info": {
+    "singularName": "help-topic",
+    "pluralName": "help-topics",
+    "displayName": "Help topic"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "sections": {
+      "type": "dynamiczone",
+      "components": [
+        "shared.rich-block",
+        "page.media-text",
+        "page.cards-grid",
+        "page.accordion",
+        "page.cta",
+        "page.faq-list"
+      ]
+    },
+    "order": {
+      "type": "integer"
+    },
+    "faqItems": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::faq-item.faq-item",
+      "mappedBy": "topic"
+    }
+  }
+}

--- a/strapi/src/api/help-topic/controllers/help_topic.ts
+++ b/strapi/src/api/help-topic/controllers/help_topic.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::help-topic.help-topic');

--- a/strapi/src/api/help-topic/routes/help_topic.ts
+++ b/strapi/src/api/help-topic/routes/help_topic.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::help-topic.help-topic');

--- a/strapi/src/api/help-topic/services/help_topic.ts
+++ b/strapi/src/api/help-topic/services/help_topic.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::help-topic.help-topic');

--- a/strapi/src/api/home-page/content-types/home-page/schema.json
+++ b/strapi/src/api/home-page/content-types/home-page/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "singleType",
+  "collectionName": "home_page",
+  "info": {
+    "singularName": "home-page",
+    "pluralName": "home-pages",
+    "displayName": "Home page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "hero": {
+      "type": "component",
+      "component": "page.hero"
+    },
+    "sections": {
+      "type": "dynamiczone",
+      "components": [
+        "shared.rich-block",
+        "page.media-text",
+        "page.cards-grid",
+        "page.accordion",
+        "page.cta",
+        "page.hero",
+        "page.faq-list"
+      ]
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    }
+  }
+}

--- a/strapi/src/api/home-page/controllers/home_page.ts
+++ b/strapi/src/api/home-page/controllers/home_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::home-page.home-page');

--- a/strapi/src/api/home-page/routes/home_page.ts
+++ b/strapi/src/api/home-page/routes/home_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::home-page.home-page');

--- a/strapi/src/api/home-page/services/home_page.ts
+++ b/strapi/src/api/home-page/services/home_page.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::home-page.home-page');

--- a/strapi/src/api/main-menu/content-types/main-menu/schema.json
+++ b/strapi/src/api/main-menu/content-types/main-menu/schema.json
@@ -1,0 +1,20 @@
+{
+  "kind": "singleType",
+  "collectionName": "main_menu",
+  "info": {
+    "singularName": "main-menu",
+    "pluralName": "main-menus",
+    "displayName": "Main menu"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "items": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::menu-item.menu-item",
+      "mappedBy": "mainMenu"
+    }
+  }
+}

--- a/strapi/src/api/main-menu/controllers/main_menu.ts
+++ b/strapi/src/api/main-menu/controllers/main_menu.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::main-menu.main-menu');

--- a/strapi/src/api/main-menu/routes/main_menu.ts
+++ b/strapi/src/api/main-menu/routes/main_menu.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::main-menu.main-menu');

--- a/strapi/src/api/main-menu/services/main_menu.ts
+++ b/strapi/src/api/main-menu/services/main_menu.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::main-menu.main-menu');

--- a/strapi/src/api/material/content-types/material/schema.json
+++ b/strapi/src/api/material/content-types/material/schema.json
@@ -1,0 +1,35 @@
+{
+  "kind": "collectionType",
+  "collectionName": "materials",
+  "info": {
+    "singularName": "material",
+    "pluralName": "materials",
+    "displayName": "Material"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "products": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product.product",
+      "mappedBy": "materials"
+    },
+    "cases": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::case.case",
+      "mappedBy": "material"
+    }
+  }
+}

--- a/strapi/src/api/material/controllers/material.ts
+++ b/strapi/src/api/material/controllers/material.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::material.material');

--- a/strapi/src/api/material/routes/material.ts
+++ b/strapi/src/api/material/routes/material.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::material.material');

--- a/strapi/src/api/material/services/material.ts
+++ b/strapi/src/api/material/services/material.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::material.material');

--- a/strapi/src/api/menu-item/content-types/menu-item/schema.json
+++ b/strapi/src/api/menu-item/content-types/menu-item/schema.json
@@ -1,0 +1,66 @@
+{
+  "kind": "collectionType",
+  "collectionName": "menu_items",
+  "info": {
+    "singularName": "menu-item",
+    "pluralName": "menu-items",
+    "displayName": "Menu item"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "type": {
+      "type": "enumeration",
+      "enum": ["link", "category", "page"],
+      "default": "link"
+    },
+    "url": {
+      "type": "string"
+    },
+    "target": {
+      "type": "enumeration",
+      "enum": ["_self", "_blank"],
+      "default": "_self"
+    },
+    "linkedCategory": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::category.category"
+    },
+    "pageSlug": {
+      "type": "string"
+    },
+    "order": {
+      "type": "integer"
+    },
+    "parent": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::menu-item.menu-item",
+      "inversedBy": "children"
+    },
+    "children": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::menu-item.menu-item",
+      "mappedBy": "parent"
+    },
+    "mainMenu": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::main-menu.main-menu",
+      "inversedBy": "items"
+    },
+    "mobileMenu": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::mobile-menu.mobile-menu",
+      "inversedBy": "items"
+    }
+  }
+}

--- a/strapi/src/api/menu-item/controllers/menu_item.ts
+++ b/strapi/src/api/menu-item/controllers/menu_item.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::menu-item.menu-item');

--- a/strapi/src/api/menu-item/routes/menu_item.ts
+++ b/strapi/src/api/menu-item/routes/menu_item.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::menu-item.menu-item');

--- a/strapi/src/api/menu-item/services/menu_item.ts
+++ b/strapi/src/api/menu-item/services/menu_item.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::menu-item.menu-item');

--- a/strapi/src/api/mobile-menu/content-types/mobile-menu/schema.json
+++ b/strapi/src/api/mobile-menu/content-types/mobile-menu/schema.json
@@ -1,0 +1,20 @@
+{
+  "kind": "singleType",
+  "collectionName": "mobile_menu",
+  "info": {
+    "singularName": "mobile-menu",
+    "pluralName": "mobile-menus",
+    "displayName": "Mobile menu"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "items": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::menu-item.menu-item",
+      "mappedBy": "mobileMenu"
+    }
+  }
+}

--- a/strapi/src/api/mobile-menu/controllers/mobile_menu.ts
+++ b/strapi/src/api/mobile-menu/controllers/mobile_menu.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::mobile-menu.mobile-menu');

--- a/strapi/src/api/mobile-menu/routes/mobile_menu.ts
+++ b/strapi/src/api/mobile-menu/routes/mobile_menu.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::mobile-menu.mobile-menu');

--- a/strapi/src/api/mobile-menu/services/mobile_menu.ts
+++ b/strapi/src/api/mobile-menu/services/mobile_menu.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::mobile-menu.mobile-menu');

--- a/strapi/src/api/order/content-types/order/schema.json
+++ b/strapi/src/api/order/content-types/order/schema.json
@@ -1,0 +1,70 @@
+{
+  "kind": "collectionType",
+  "collectionName": "orders",
+  "info": {
+    "singularName": "order",
+    "pluralName": "orders",
+    "displayName": "Order"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "status": {
+      "type": "enumeration",
+      "enum": ["new", "awaiting_confirmation", "ready_to_ship", "cancelled"],
+      "default": "new"
+    },
+    "total": {
+      "type": "decimal",
+      "min": 0,
+      "required": true
+    },
+    "currency": {
+      "type": "string",
+      "default": "RUB"
+    },
+    "deliveryCost": {
+      "type": "decimal",
+      "min": 0
+    },
+    "deliveryMethod": {
+      "type": "string"
+    },
+    "freeShippingApplied": {
+      "type": "boolean",
+      "default": false
+    },
+    "address": {
+      "type": "component",
+      "component": "commerce.address"
+    },
+    "customer": {
+      "type": "component",
+      "component": "commerce.customer"
+    },
+    "items": {
+      "type": "component",
+      "component": "commerce.order-item",
+      "repeatable": true,
+      "required": true
+    },
+    "events": {
+      "type": "component",
+      "component": "commerce.order-event",
+      "repeatable": true
+    },
+    "source": {
+      "type": "string"
+    },
+    "utm": {
+      "type": "json"
+    },
+    "ip": {
+      "type": "string"
+    },
+    "userAgent": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/api/order/controllers/order.ts
+++ b/strapi/src/api/order/controllers/order.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::order.order');

--- a/strapi/src/api/order/routes/order.ts
+++ b/strapi/src/api/order/routes/order.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::order.order');

--- a/strapi/src/api/order/services/order.ts
+++ b/strapi/src/api/order/services/order.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::order.order');

--- a/strapi/src/api/printing-method/content-types/printing-method/schema.json
+++ b/strapi/src/api/printing-method/content-types/printing-method/schema.json
@@ -1,0 +1,35 @@
+{
+  "kind": "collectionType",
+  "collectionName": "printing_methods",
+  "info": {
+    "singularName": "printing-method",
+    "pluralName": "printing-methods",
+    "displayName": "Printing method"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "products": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product.product",
+      "mappedBy": "printingMethods"
+    },
+    "cases": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::case.case",
+      "mappedBy": "appliedMethods"
+    }
+  }
+}

--- a/strapi/src/api/printing-method/controllers/printing_method.ts
+++ b/strapi/src/api/printing-method/controllers/printing_method.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::printing-method.printing-method');

--- a/strapi/src/api/printing-method/routes/printing_method.ts
+++ b/strapi/src/api/printing-method/routes/printing_method.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::printing-method.printing-method');

--- a/strapi/src/api/printing-method/services/printing_method.ts
+++ b/strapi/src/api/printing-method/services/printing_method.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::printing-method.printing-method');

--- a/strapi/src/api/product-variant/content-types/product-variant/schema.json
+++ b/strapi/src/api/product-variant/content-types/product-variant/schema.json
@@ -1,0 +1,67 @@
+{
+  "kind": "collectionType",
+  "collectionName": "product_variants",
+  "info": {
+    "singularName": "product-variant",
+    "pluralName": "product-variants",
+    "displayName": "Product variant"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "sku": {
+      "type": "string",
+      "required": true
+    },
+    "isDefault": {
+      "type": "boolean",
+      "default": false
+    },
+    "images": {
+      "type": "component",
+      "component": "shared.image",
+      "repeatable": true
+    },
+    "price": {
+      "type": "decimal",
+      "min": 0
+    },
+    "stock": {
+      "type": "integer"
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": ["in_stock", "preorder", "out_of_stock"],
+      "default": "in_stock"
+    },
+    "attributeValues": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::attribute-value.attribute-value",
+      "inversedBy": "variants"
+    },
+    "product": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product.product",
+      "inversedBy": "variants"
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    },
+    "badges": {
+      "type": "json"
+    }
+  }
+}

--- a/strapi/src/api/product-variant/controllers/product_variant.ts
+++ b/strapi/src/api/product-variant/controllers/product_variant.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::product-variant.product-variant');

--- a/strapi/src/api/product-variant/routes/product_variant.ts
+++ b/strapi/src/api/product-variant/routes/product_variant.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::product-variant.product-variant');

--- a/strapi/src/api/product-variant/services/product_variant.ts
+++ b/strapi/src/api/product-variant/services/product_variant.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::product-variant.product-variant');

--- a/strapi/src/api/product/content-types/product/schema.json
+++ b/strapi/src/api/product/content-types/product/schema.json
@@ -1,0 +1,157 @@
+{
+  "kind": "collectionType",
+  "collectionName": "products",
+  "info": {
+    "singularName": "product",
+    "pluralName": "products",
+    "displayName": "Product"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "sku": {
+      "type": "string",
+      "unique": true
+    },
+    "externalId": {
+      "type": "string",
+      "unique": true
+    },
+    "excerpt": {
+      "type": "text"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "images": {
+      "type": "component",
+      "component": "shared.image",
+      "repeatable": true
+    },
+    "attachments": {
+      "type": "media",
+      "allowedTypes": ["files"],
+      "multiple": true
+    },
+    "videoLinks": {
+      "type": "json"
+    },
+    "brand": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::brand.brand",
+      "inversedBy": "products"
+    },
+    "baseCategory": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::category.category",
+      "inversedBy": "products"
+    },
+    "subCategories": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::category.category",
+      "inversedBy": "products"
+    },
+    "materials": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::material.material",
+      "inversedBy": "products"
+    },
+    "printingMethods": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::printing-method.printing-method",
+      "inversedBy": "products"
+    },
+    "attributeValues": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::attribute-value.attribute-value",
+      "inversedBy": "products"
+    },
+    "logoEnabled": {
+      "type": "boolean",
+      "default": false
+    },
+    "logoMethods": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::printing-method.printing-method"
+    },
+    "logoArea": {
+      "type": "component",
+      "component": "product.geometry"
+    },
+    "designTemplates": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::design-template.design-template",
+      "mappedBy": "product"
+    },
+    "priceType": {
+      "type": "enumeration",
+      "enum": ["fixed", "tiered"],
+      "default": "fixed"
+    },
+    "priceFrom": {
+      "type": "decimal",
+      "min": 0
+    },
+    "MOQ": {
+      "type": "integer",
+      "min": 1
+    },
+    "tieredPrices": {
+      "type": "component",
+      "component": "product.tiered-price",
+      "repeatable": true
+    },
+    "specs": {
+      "type": "component",
+      "component": "product.spec-item",
+      "repeatable": true
+    },
+    "seo": {
+      "type": "component",
+      "component": "shared.seo"
+    },
+    "badges": {
+      "type": "json"
+    },
+    "rating": {
+      "type": "decimal",
+      "min": 0,
+      "max": 5
+    },
+    "cases": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::case.case",
+      "mappedBy": "product"
+    },
+    "related": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product.product"
+    },
+    "variants": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::product-variant.product-variant",
+      "mappedBy": "product"
+    }
+  }
+}

--- a/strapi/src/api/product/controllers/product.ts
+++ b/strapi/src/api/product/controllers/product.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::product.product');

--- a/strapi/src/api/product/routes/product.ts
+++ b/strapi/src/api/product/routes/product.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::product.product');

--- a/strapi/src/api/product/services/product.ts
+++ b/strapi/src/api/product/services/product.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::product.product');

--- a/strapi/src/api/quote-request/content-types/quote-request/schema.json
+++ b/strapi/src/api/quote-request/content-types/quote-request/schema.json
@@ -1,0 +1,60 @@
+{
+  "kind": "collectionType",
+  "collectionName": "quote_requests",
+  "info": {
+    "singularName": "quote-request",
+    "pluralName": "quote-requests",
+    "displayName": "Quote request"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "qty": {
+      "type": "integer",
+      "min": 1,
+      "required": true
+    },
+    "company": {
+      "type": "string"
+    },
+    "email": {
+      "type": "email",
+      "required": true
+    },
+    "phone": {
+      "type": "string",
+      "required": true
+    },
+    "message": {
+      "type": "text"
+    },
+    "attributesSnapshot": {
+      "type": "json"
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": ["new", "processed", "replied"],
+      "default": "new"
+    },
+    "source": {
+      "type": "string"
+    },
+    "utm": {
+      "type": "json"
+    },
+    "ip": {
+      "type": "string"
+    },
+    "product": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product.product"
+    },
+    "variant": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product-variant.product-variant"
+    }
+  }
+}

--- a/strapi/src/api/quote-request/controllers/quote_request.ts
+++ b/strapi/src/api/quote-request/controllers/quote_request.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::quote-request.quote-request');

--- a/strapi/src/api/quote-request/routes/quote_request.ts
+++ b/strapi/src/api/quote-request/routes/quote_request.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::quote-request.quote-request');

--- a/strapi/src/api/quote-request/services/quote_request.ts
+++ b/strapi/src/api/quote-request/services/quote_request.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::quote-request.quote-request');

--- a/strapi/src/api/settings-seo/content-types/settings-seo/schema.json
+++ b/strapi/src/api/settings-seo/content-types/settings-seo/schema.json
@@ -1,0 +1,24 @@
+{
+  "kind": "singleType",
+  "collectionName": "settings_seo",
+  "info": {
+    "singularName": "settings-seo",
+    "pluralName": "settings-seos",
+    "displayName": "Settings SEO"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "defaultSeo": {
+      "type": "component",
+      "component": "shared.seo"
+    },
+    "robots": {
+      "type": "text"
+    },
+    "sitemapUrl": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/api/settings-seo/controllers/settings_seo.ts
+++ b/strapi/src/api/settings-seo/controllers/settings_seo.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::settings-seo.settings-seo');

--- a/strapi/src/api/settings-seo/routes/settings_seo.ts
+++ b/strapi/src/api/settings-seo/routes/settings_seo.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::settings-seo.settings-seo');

--- a/strapi/src/api/settings-seo/services/settings_seo.ts
+++ b/strapi/src/api/settings-seo/services/settings_seo.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::settings-seo.settings-seo');

--- a/strapi/src/api/site-setting/content-types/site-setting/schema.json
+++ b/strapi/src/api/site-setting/content-types/site-setting/schema.json
@@ -1,0 +1,44 @@
+{
+  "kind": "singleType",
+  "collectionName": "site_settings",
+  "info": {
+    "singularName": "site-setting",
+    "pluralName": "site-settings",
+    "displayName": "Site settings"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "companyName": {
+      "type": "string"
+    },
+    "primaryPhone": {
+      "type": "string"
+    },
+    "primaryEmail": {
+      "type": "email"
+    },
+    "channels": {
+      "type": "component",
+      "component": "contact.channel",
+      "repeatable": true
+    },
+    "ga4MeasurementId": {
+      "type": "string"
+    },
+    "gtmId": {
+      "type": "string"
+    },
+    "freeShippingThreshold": {
+      "type": "integer",
+      "default": 100000
+    },
+    "notificationEmails": {
+      "type": "json"
+    },
+    "featureFlags": {
+      "type": "json"
+    }
+  }
+}

--- a/strapi/src/api/site-setting/controllers/site-setting.ts
+++ b/strapi/src/api/site-setting/controllers/site-setting.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::site-setting.site-setting');

--- a/strapi/src/api/site-setting/routes/site-setting.ts
+++ b/strapi/src/api/site-setting/routes/site-setting.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::site-setting.site-setting');

--- a/strapi/src/api/site-setting/services/site-setting.ts
+++ b/strapi/src/api/site-setting/services/site-setting.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::site-setting.site-setting');

--- a/strapi/src/api/video-asset/content-types/video-asset/schema.json
+++ b/strapi/src/api/video-asset/content-types/video-asset/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "video_assets",
+  "info": {
+    "singularName": "video-asset",
+    "pluralName": "video-assets",
+    "displayName": "Video asset"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "sourceUrl": {
+      "type": "string"
+    },
+    "file": {
+      "type": "media",
+      "allowedTypes": ["videos"],
+      "multiple": false
+    },
+    "cover": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    },
+    "product": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product.product"
+    },
+    "variant": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::product-variant.product-variant"
+    }
+  }
+}

--- a/strapi/src/api/video-asset/controllers/video_asset.ts
+++ b/strapi/src/api/video-asset/controllers/video_asset.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::video-asset.video-asset');

--- a/strapi/src/api/video-asset/routes/video_asset.ts
+++ b/strapi/src/api/video-asset/routes/video_asset.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::video-asset.video-asset');

--- a/strapi/src/api/video-asset/services/video_asset.ts
+++ b/strapi/src/api/video-asset/services/video_asset.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::video-asset.video-asset');

--- a/strapi/src/components/commerce/address.json
+++ b/strapi/src/components/commerce/address.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_commerce_addresses",
+  "info": {
+    "displayName": "Address",
+    "icon": "map"
+  },
+  "options": {},
+  "attributes": {
+    "postalCode": {
+      "type": "string"
+    },
+    "city": {
+      "type": "string"
+    },
+    "street": {
+      "type": "string"
+    },
+    "comment": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/commerce/customer.json
+++ b/strapi/src/components/commerce/customer.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_commerce_customers",
+  "info": {
+    "displayName": "Customer",
+    "icon": "user"
+  },
+  "options": {},
+  "attributes": {
+    "fullName": {
+      "type": "string",
+      "required": true
+    },
+    "company": {
+      "type": "string"
+    },
+    "inn": {
+      "type": "string"
+    },
+    "email": {
+      "type": "email",
+      "required": true
+    },
+    "phone": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/strapi/src/components/commerce/order-event.json
+++ b/strapi/src/components/commerce/order-event.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_commerce_order_events",
+  "info": {
+    "displayName": "Order event",
+    "icon": "time"
+  },
+  "options": {},
+  "attributes": {
+    "timestamp": {
+      "type": "datetime",
+      "required": true
+    },
+    "type": {
+      "type": "string",
+      "required": true
+    },
+    "payload": {
+      "type": "json"
+    },
+    "comment": {
+      "type": "text"
+    }
+  }
+}

--- a/strapi/src/components/commerce/order-item.json
+++ b/strapi/src/components/commerce/order-item.json
@@ -1,0 +1,39 @@
+{
+  "collectionName": "components_commerce_order_items",
+  "info": {
+    "displayName": "Order item",
+    "icon": "shopping-cart"
+  },
+  "options": {},
+  "attributes": {
+    "productId": {
+      "type": "string",
+      "required": true
+    },
+    "variantId": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "attributesSnapshot": {
+      "type": "json"
+    },
+    "price": {
+      "type": "decimal",
+      "min": 0,
+      "required": true
+    },
+    "qty": {
+      "type": "integer",
+      "min": 1,
+      "required": true
+    },
+    "sum": {
+      "type": "decimal",
+      "min": 0,
+      "required": true
+    }
+  }
+}

--- a/strapi/src/components/contact/channel.json
+++ b/strapi/src/components/contact/channel.json
@@ -1,0 +1,34 @@
+{
+  "collectionName": "components_contact_channels",
+  "info": {
+    "displayName": "Contact channel",
+    "icon": "phone"
+  },
+  "options": {},
+  "attributes": {
+    "label": {
+      "type": "string",
+      "required": true
+    },
+    "type": {
+      "type": "enumeration",
+      "enum": [
+        "phone",
+        "email",
+        "telegram",
+        "whatsapp",
+        "viber",
+        "skype",
+        "other"
+      ],
+      "default": "other"
+    },
+    "value": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/contact/location.json
+++ b/strapi/src/components/contact/location.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_contact_locations",
+  "info": {
+    "displayName": "Location",
+    "icon": "pin"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "address": {
+      "type": "component",
+      "component": "commerce.address",
+      "required": true
+    },
+    "workingHours": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/navigation/footer-column.json
+++ b/strapi/src/components/navigation/footer-column.json
@@ -1,0 +1,18 @@
+{
+  "collectionName": "components_navigation_footer_columns",
+  "info": {
+    "displayName": "Footer column",
+    "icon": "column"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "links": {
+      "type": "component",
+      "component": "navigation.link",
+      "repeatable": true
+    }
+  }
+}

--- a/strapi/src/components/navigation/link.json
+++ b/strapi/src/components/navigation/link.json
@@ -1,0 +1,23 @@
+{
+  "collectionName": "components_navigation_links",
+  "info": {
+    "displayName": "Link",
+    "icon": "link"
+  },
+  "options": {},
+  "attributes": {
+    "label": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    },
+    "target": {
+      "type": "enumeration",
+      "enum": ["_self", "_blank"],
+      "default": "_self"
+    }
+  }
+}

--- a/strapi/src/components/page/accordion-item.json
+++ b/strapi/src/components/page/accordion-item.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_page_accordion_items",
+  "info": {
+    "displayName": "Accordion item",
+    "icon": "question"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "content": {
+      "type": "richtext"
+    }
+  }
+}

--- a/strapi/src/components/page/accordion.json
+++ b/strapi/src/components/page/accordion.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_page_accordions",
+  "info": {
+    "displayName": "Accordion",
+    "icon": "align-justify"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "items": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page.accordion-item",
+      "required": true
+    }
+  }
+}

--- a/strapi/src/components/page/cards-grid-item.json
+++ b/strapi/src/components/page/cards-grid-item.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_page_cards_grid_items",
+  "info": {
+    "displayName": "Card item",
+    "icon": "dashboard"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "icon": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    }
+  }
+}

--- a/strapi/src/components/page/cards-grid.json
+++ b/strapi/src/components/page/cards-grid.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_page_cards_grids",
+  "info": {
+    "displayName": "Cards grid",
+    "icon": "grid"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "items": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page.cards-grid-item",
+      "required": true
+    }
+  }
+}

--- a/strapi/src/components/page/cta.json
+++ b/strapi/src/components/page/cta.json
@@ -1,0 +1,23 @@
+{
+  "collectionName": "components_page_ctas",
+  "info": {
+    "displayName": "CTA",
+    "icon": "bullhorn"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "subtitle": {
+      "type": "text"
+    },
+    "buttonLabel": {
+      "type": "string"
+    },
+    "buttonUrl": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/page/faq-list.json
+++ b/strapi/src/components/page/faq-list.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_page_faq_lists",
+  "info": {
+    "displayName": "FAQ list",
+    "icon": "question"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "items": {
+      "type": "component",
+      "component": "page.accordion-item",
+      "repeatable": true,
+      "required": true
+    }
+  }
+}

--- a/strapi/src/components/page/hero.json
+++ b/strapi/src/components/page/hero.json
@@ -1,0 +1,33 @@
+{
+  "collectionName": "components_page_heros",
+  "info": {
+    "displayName": "Hero",
+    "icon": "star"
+  },
+  "options": {},
+  "attributes": {
+    "eyebrow": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "subtitle": {
+      "type": "text"
+    },
+    "background": {
+      "type": "component",
+      "component": "shared.image"
+    },
+    "badge": {
+      "type": "string"
+    },
+    "ctaLabel": {
+      "type": "string"
+    },
+    "ctaUrl": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/page/media-text.json
+++ b/strapi/src/components/page/media-text.json
@@ -1,0 +1,34 @@
+{
+  "collectionName": "components_page_media_texts",
+  "info": {
+    "displayName": "Media & text",
+    "icon": "layout"
+  },
+  "options": {},
+  "attributes": {
+    "eyebrow": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "richtext"
+    },
+    "image": {
+      "type": "component",
+      "component": "shared.image"
+    },
+    "imagePosition": {
+      "type": "enumeration",
+      "enum": ["left", "right"],
+      "default": "right"
+    },
+    "ctaLabel": {
+      "type": "string"
+    },
+    "ctaUrl": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/product/attribute-badge.json
+++ b/strapi/src/components/product/attribute-badge.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_product_attribute_badges",
+  "info": {
+    "displayName": "Attribute badge",
+    "icon": "tag"
+  },
+  "options": {},
+  "attributes": {
+    "label": {
+      "type": "string",
+      "required": true
+    },
+    "value": {
+      "type": "string",
+      "required": true
+    },
+    "hex": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/product/geometry.json
+++ b/strapi/src/components/product/geometry.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_product_geometries",
+  "info": {
+    "displayName": "Logo geometry",
+    "icon": "vector-square"
+  },
+  "options": {},
+  "attributes": {
+    "width": {
+      "type": "decimal",
+      "min": 0
+    },
+    "height": {
+      "type": "decimal",
+      "min": 0
+    },
+    "offsetX": {
+      "type": "decimal"
+    },
+    "offsetY": {
+      "type": "decimal"
+    },
+    "note": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/product/spec-item.json
+++ b/strapi/src/components/product/spec-item.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_product_spec_items",
+  "info": {
+    "displayName": "Spec item",
+    "icon": "list"
+  },
+  "options": {},
+  "attributes": {
+    "label": {
+      "type": "string",
+      "required": true
+    },
+    "value": {
+      "type": "string",
+      "required": true
+    },
+    "unit": {
+      "type": "string"
+    },
+    "note": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/product/tiered-price.json
+++ b/strapi/src/components/product/tiered-price.json
@@ -1,0 +1,23 @@
+{
+  "collectionName": "components_product_tiered_prices",
+  "info": {
+    "displayName": "Tiered price",
+    "icon": "chart-bar"
+  },
+  "options": {},
+  "attributes": {
+    "minQty": {
+      "type": "integer",
+      "min": 1,
+      "required": true
+    },
+    "price": {
+      "type": "decimal",
+      "min": 0,
+      "required": true
+    },
+    "note": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/components/shared/image.json
+++ b/strapi/src/components/shared/image.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_shared_images",
+  "info": {
+    "displayName": "Image",
+    "icon": "image"
+  },
+  "options": {},
+  "attributes": {
+    "image": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false,
+      "required": true
+    },
+    "alt": {
+      "type": "string"
+    },
+    "focalPoint": {
+      "type": "json"
+    }
+  }
+}

--- a/strapi/src/components/shared/rich-block.json
+++ b/strapi/src/components/shared/rich-block.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_shared_rich_blocks",
+  "info": {
+    "displayName": "Rich block",
+    "icon": "align-left"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "body": {
+      "type": "richtext"
+    }
+  }
+}

--- a/strapi/src/components/shared/seo.json
+++ b/strapi/src/components/shared/seo.json
@@ -1,0 +1,23 @@
+{
+  "collectionName": "components_shared_seos",
+  "info": {
+    "displayName": "SEO",
+    "icon": "robot"
+  },
+  "options": {},
+  "attributes": {
+    "metaTitle": {
+      "type": "string",
+      "maxLength": 60
+    },
+    "metaDescription": {
+      "type": "text",
+      "maxLength": 160
+    },
+    "ogImage": {
+      "type": "media",
+      "allowedTypes": ["images"],
+      "multiple": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- rename the Site settings API directory to match the single-type singular key expected by Strapi
- update the controller, router, and service to use the corrected `api::site-setting.site-setting` UID so the CMS boots cleanly

## Testing
- `pnpm --filter strapi strapi build` *(fails: strapi binary missing because node_modules are not installed in the container)*

## References
- Internal: docs/Проектирование интернет-магазина Marcus (Next.js + Strapi).md → §2 Модель данных → Single-types


------
https://chatgpt.com/codex/tasks/task_b_68e402d3ce1483299a4d35de0d0a010f