### PR TITLE
fix: update strapi s3 provider options

### DIFF
--- a/strapi/config/plugins.ts
+++ b/strapi/config/plugins.ts
@@ -42,16 +42,20 @@ export default ({ env }: { env: any }) => {
       config: {
         provider: 'aws-s3',
         providerOptions: {
-          accessKeyId: env('S3_ACCESS_KEY_ID'),
-          secretAccessKey: env('S3_SECRET_ACCESS_KEY'),
-          region: env('S3_REGION'),
-          ...(env('S3_ENDPOINT') ? { endpoint: env('S3_ENDPOINT') } : {}),
-          forcePathStyle: env.bool('S3_FORCE_PATH_STYLE', false),
           baseUrl: env('S3_CDN_BASE_URL'),
-          params: {
-            ACL: env('S3_ACL', 'public-read'),
-            signedUrlExpires: env.int('S3_SIGNED_URL_EXPIRES', 15 * 60),
-            Bucket: env('S3_BUCKET'),
+          s3Options: {
+            ...(env('S3_ENDPOINT') ? { endpoint: env('S3_ENDPOINT') } : {}),
+            region: env('S3_REGION'),
+            forcePathStyle: env.bool('S3_FORCE_PATH_STYLE', false),
+            credentials: {
+              accessKeyId: env('S3_ACCESS_KEY_ID'),
+              secretAccessKey: env('S3_SECRET_ACCESS_KEY'),
+            },
+            params: {
+              ACL: env('S3_ACL', 'public-read'),
+              signedUrlExpires: env.int('S3_SIGNED_URL_EXPIRES', 15 * 60),
+              Bucket: env('S3_BUCKET'),
+            },
           },
         },
         actionOptions: {


### PR DESCRIPTION
## Summary
- nest AWS credentials inside `s3Options` so Strapi v5 passes them to the `S3Client`

## Testing
- not run (docker compose dev rebuild not executed in CI environment)

## References
- External: Strapi documentation — https://docs.strapi.io/dev-docs/providers/amazon-s3

------
https://chatgpt.com/codex/tasks/task_b_68e650507d6c832985ad315c9b04cfc8