### PR TITLE
Adjust Strapi CSP for S3 assets

### DIFF
--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,12 +1,36 @@
-export default [
-  'strapi::logger',
-  'strapi::errors',
-  'strapi::security',
-  'strapi::cors',
-  'strapi::poweredBy',
-  'strapi::query',
-  'strapi::body',
-  'strapi::session',
-  'strapi::favicon',
-  'strapi::public',
-];
+export default ({ env }) => {
+  const hosts = ['https://market-assets.strapi.io'];
+
+  const s3CdnBaseUrl = env('S3_CDN_BASE_URL');
+  const s3Endpoint = env('S3_ENDPOINT');
+
+  if (s3CdnBaseUrl) {
+    hosts.push(s3CdnBaseUrl.replace(/\/$/, ''));
+  } else if (s3Endpoint) {
+    hosts.push(s3Endpoint.replace(/\/$/, ''));
+  }
+
+  return [
+    'strapi::logger',
+    'strapi::errors',
+    {
+      name: 'strapi::security',
+      config: {
+        contentSecurityPolicy: {
+          useDefaults: true,
+          directives: {
+            'img-src': ["'self'", 'data:', 'blob:', ...hosts],
+            'media-src': [...hosts],
+          },
+        },
+      },
+    },
+    'strapi::cors',
+    'strapi::poweredBy',
+    'strapi::query',
+    'strapi::body',
+    'strapi::session',
+    'strapi::favicon',
+    'strapi::public',
+  ];
+};


### PR DESCRIPTION
## Summary
- wrap the Strapi middleware export to access environment values
- build an allowlist for S3 media hosts including the legacy market assets CDN
- extend the security middleware configuration to emit custom CSP directives for images and media

## Testing
- pnpm dev *(fails: strapi binary missing because dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68e656715ca0832984ffef371ead7f70