### PR TITLE
Normalize S3 CSP hosts

### DIFF
--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,12 +1,62 @@
-export default [
-  'strapi::logger',
-  'strapi::errors',
-  'strapi::security',
-  'strapi::cors',
-  'strapi::poweredBy',
-  'strapi::query',
-  'strapi::body',
-  'strapi::session',
-  'strapi::favicon',
-  'strapi::public',
-];
+export default ({ env }) => {
+  const hosts = ['https://market-assets.strapi.io'];
+
+  const appendHost = (value?: string) => {
+    if (!value) {
+      return;
+    }
+
+    const trimmed = value.replace(/\/$/, '');
+
+    try {
+      const { origin } = new URL(trimmed);
+
+      hosts.push(origin);
+
+      if (trimmed !== origin) {
+        hosts.push(trimmed);
+      }
+
+      return;
+    } catch (error) {
+      // ignore parsing error and fall back to trimmed value
+    }
+
+    hosts.push(trimmed);
+  };
+
+  const s3CdnBaseUrl = env('S3_CDN_BASE_URL');
+  const s3Endpoint = env('S3_ENDPOINT');
+
+  if (s3CdnBaseUrl) {
+    appendHost(s3CdnBaseUrl);
+  } else if (s3Endpoint) {
+    appendHost(s3Endpoint);
+  }
+
+  const uniqueHosts = Array.from(new Set(hosts));
+
+  return [
+    'strapi::logger',
+    'strapi::errors',
+    {
+      name: 'strapi::security',
+      config: {
+        contentSecurityPolicy: {
+          useDefaults: true,
+          directives: {
+            'img-src': ["'self'", 'data:', 'blob:', ...uniqueHosts],
+            'media-src': [...uniqueHosts],
+          },
+        },
+      },
+    },
+    'strapi::cors',
+    'strapi::poweredBy',
+    'strapi::query',
+    'strapi::body',
+    'strapi::session',
+    'strapi::favicon',
+    'strapi::public',
+  ];
+};


### PR DESCRIPTION
## Summary
- normalize the S3 media allowlist by parsing configured CDN/endpoint URLs to their origins
- de-duplicate the generated host directives before applying the CSP middleware

## Testing
- not run (not requested)

**References**
- Internal: n/a


------
https://chatgpt.com/codex/tasks/task_b_68e656715ca0832984ffef371ead7f70