### PR TITLE
Fix CSP to allow Media Library previews

### DIFF
--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,7 +1,23 @@
+const mediaDirectives = [
+  'https://market-assets.strapi.io',
+  'https://*.itts.su',
+];
+
 export default [
   'strapi::logger',
   'strapi::errors',
-  'strapi::security',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'img-src': ["'self'", 'data:', 'blob:', ...mediaDirectives],
+          'media-src': ["'self'", 'data:', 'blob:', ...mediaDirectives],
+        },
+      },
+    },
+  },
   'strapi::cors',
   'strapi::poweredBy',
   'strapi::query',


### PR DESCRIPTION
## Summary
- whitelist the itts.su media domain in the Strapi security middleware CSP
- extend the media-src directive so admin previews can load uploaded files

## Testing
- not run

## References
- External: Strapi v5 docs — https://docs.strapi.io/dev-docs/configurations/middlewares#configuration

------
https://chatgpt.com/codex/tasks/task_b_68ea6a1438b88329ba282b01f02d5b81